### PR TITLE
Remove homebrew from specials dirs since it is too general

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         args: ['--maxkb=1000']
       - id: check-merge-conflict
       - id: check-toml
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-tqdm"]

--- a/test_unit.py
+++ b/test_unit.py
@@ -109,7 +109,6 @@ class TestIdentifySpecialDirName:
         assert identify_special_dir_name(".deno") == "Package Caches"
         assert identify_special_dir_name(".pnpm") == "Package Caches"
         assert identify_special_dir_name(".uv") == "Package Caches"
-        assert identify_special_dir_name("Homebrew") == "Package Caches"
 
     def test_ide_config(self):
         assert identify_special_dir_name(".idea") == "IDE Config"

--- a/zpace/config.py
+++ b/zpace/config.py
@@ -190,7 +190,6 @@ DEFAULT_SPECIAL_DIRS: Dict[str, Set[str]] = {
         ".bundle",
         ".bun",
         ".deno",
-        "homebrew",
     },
     "IDE Config": {".idea", ".vscode", ".vs", ".eclipse", ".fleet"},
     "Git Repos": {".git"},

--- a/zpace/core.py
+++ b/zpace/core.py
@@ -1,5 +1,5 @@
-import os
 import heapq
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -8,12 +8,12 @@ from tqdm import tqdm
 
 from zpace.config import (
     DEEPEST_SKIP_LEVEL,
+    DEFAULT_TOP_N,
     EXTENSION_MAP,
     MIN_FILE_SIZE,
     PROGRESS_UPDATE_THRESHOLD,
     SKIP_DIRS,
     SPECIAL_DIR_MAP,
-    DEFAULT_TOP_N,
 )
 
 


### PR DESCRIPTION
Add mypy to pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added mypy to pre-commit checks to enforce type checking.
  * Removed "homebrew" from the set of recognized package cache directories.
* **Tests**
  * Updated unit tests to remove the assertion that "Homebrew" maps to the package cache category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->